### PR TITLE
Add diversity matters page section with explanation on ticket sale waves

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,9 @@
                                 <a href="#about">About</a>
                             </li>
                             <li>
+                                <a href="#ticket-sales">Ticket sales</a>
+                            </li>
+                            <li>
                                 <a href="#diversity">Diversity Matters</a>
                             </li>
                             <li>
@@ -263,6 +266,33 @@
                 </div>
             </section>
             <!-- /PAGE ABOUT -->
+            <!-- PAGE TICKET SALES -->
+            <section class="page-section" id="ticket-sales">
+                <div class="container">
+                    <h1 class="section-title">
+                        <span data-animation="flipInY" data-animation-delay="300" class="icon-inner"><span
+                                class="fa-stack"><i class="fa rhex fa-stack-2x"></i><i
+                                class="fa fa-star fa-stack-1x"></i></span></span>
+                        <span data-animation="fadeInRight" data-animation-delay="500" class="title-inner">Ticket sales <small>/ Be ready!</small></span>
+                    </h1>
+                    <div class="row">
+                        <div class="col-lg-12">
+                            <p>
+                                This year we will release tickets in three different waves:
+                            <ul>
+                                <li>July 1<sup>st</sup>: 100 tickets, including 50 tickets reserved for
+                                    underrepresented groups in tech
+                                </li>
+                                <li>August 1<sup>st</sup>: 50 tickets</li>
+                                <li>September 1<sup>st</sup>: 50 tickets</li>
+                            </ul>
+                            </p>
+
+                        </div>
+                    </div>
+                </div>
+            </section>
+            <!-- /PAGE TICKET SALES -->
             <!-- PAGE DIVERSITY -->
             <section class="page-section" id="diversity">
                 <div class="container">
@@ -273,7 +303,7 @@
                         <span data-animation="fadeInRight" data-animation-delay="500" class="title-inner">Diversity Matters <small>/ We welcome you</small></span>
                     </h1>
                     <div class="row">
-                        <div class="col-lg-8">
+                        <div class="col-lg-12">
                             <p data-animation="fadeInUp" data-animation-delay="300">
                                 For those of you who feel part of an underrepresented group in tech, we welcome
                                 you.
@@ -282,16 +312,6 @@
                                 We want to support you by reserving tickets for 50 people on the first
                                 ticket sale wave. This includes (but is not limited to): people of
                                 colour, disabled people, LGBTQIA+ people and women.
-                            </p>
-                            <p>
-                                This year we will release tickets in three different waves:
-                            <ul>
-                                <li>July 1<sup>st</sup>: 100 tickets, including 50 tickets reserved for
-                                    underrepresented groups in tech
-                                </li>
-                                <li>August 1<sup>st</sup>: 50 tickets</li>
-                                <li>September 1<sup>st</sup>: 50 tickets</li>
-                            </ul>
                             </p>
                             <p>If you feel you are part of an underrepresented group in tech, let us know!</p>
                         </div>

--- a/index.html
+++ b/index.html
@@ -74,6 +74,9 @@
                                 <a href="#about">About</a>
                             </li>
                             <li>
+                                <a href="#diversity">Diversity Matters</a>
+                            </li>
+                            <li>
                                 <a href="2016/index.html">2016</a>
                             </li>
                         </ul>
@@ -260,7 +263,42 @@
                 </div>
             </section>
             <!-- /PAGE ABOUT -->
-
+            <!-- PAGE DIVERSITY -->
+            <section class="page-section" id="diversity">
+                <div class="container">
+                    <h1 class="section-title">
+                        <span data-animation="flipInY" data-animation-delay="300" class="icon-inner"><span
+                                class="fa-stack"><i class="fa rhex fa-stack-2x"></i><i
+                                class="fa fa-star fa-stack-1x"></i></span></span>
+                        <span data-animation="fadeInRight" data-animation-delay="500" class="title-inner">Diversity Matters <small>/ We welcome you</small></span>
+                    </h1>
+                    <div class="row">
+                        <div class="col-lg-8">
+                            <p data-animation="fadeInUp" data-animation-delay="300">
+                                For those of you who feel part of an underrepresented group in tech, we welcome
+                                you.
+                            </p>
+                            <p>
+                                We want to support you by reserving tickets for 50 people on the first
+                                ticket sale wave. This includes (but is not limited to): people of
+                                colour, disabled people, LGBTQIA+ people and women.
+                            </p>
+                            <p>
+                                This year we will release tickets in three different waves:
+                            <ul>
+                                <li>July 1<sup>st</sup>: 100 tickets, including 50 tickets reserved for
+                                    underrepresented groups in tech
+                                </li>
+                                <li>August 1<sup>st</sup>: 50 tickets</li>
+                                <li>September 1<sup>st</sup>: 50 tickets</li>
+                            </ul>
+                            </p>
+                            <p>If you feel you are part of an underrepresented group in tech, let us know!</p>
+                        </div>
+                    </div>
+                </div>
+            </section>
+            <!-- /PAGE DIVERSITY -->
             <!-- PAGE SPONSORS -->
 
             <!-- /PAGE SPONSORS -->


### PR DESCRIPTION
Original idea taken from: https://ti.to/bpconferences/craft-conference-2017/en

Maybe we should consider adding a diversity statement (I would suggest to use the following: http://www.dreamwidth.org/legal/diversity
If we do so, then we could rename this section to **Tickets** and reword it a little bit. 

