### PR TITLE
Move Code of Conduct to its own page reducing the homepage scroll size

### DIFF
--- a/coc.html
+++ b/coc.html
@@ -1,0 +1,185 @@
+<!DOCTYPE html>
+<!--[if lt IE 7 ]><html class="ie ie6" lang="en"><![endif]-->
+<!--[if IE 7 ]><html class="ie ie7" lang="en"><![endif]-->
+<!--[if IE 8 ]><html class="ie ie8" lang="en"><![endif]-->
+<!--[if (gte IE 9)|!(IE)]><!--><html lang="en"><!--<![endif]-->
+<head>
+    <meta charset="utf-8">
+    <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <title>Software Craftsmanship Barcelona 2017 | Code of Conduct</title>
+
+    <!-- Favicons -->
+    <link rel="apple-touch-icon-precomposed" sizes="144x144" href="assets/ico/apple-touch-icon-144-precomposed.png">
+    <link rel="shortcut icon" href="assets/ico/favicon.ico">
+
+    <!-- CSS Global -->
+    <link href="assets/plugins/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+    <link href="assets/plugins/fontawesome/css/font-awesome.min.css" rel="stylesheet">
+    <link href="assets/plugins/bootstrap-select/bootstrap-select.min.css" rel="stylesheet">
+    <link href="assets/plugins/owlcarousel2/assets/owl.carousel.min.css" rel="stylesheet">
+    <link href="assets/plugins/owlcarousel2/assets/owl.theme.default.min.css" rel="stylesheet">
+    <link href="assets/plugins/prettyphoto/css/prettyPhoto.css" rel="stylesheet">
+    <link href="assets/plugins/animate/animate.min.css" rel="stylesheet">
+
+    <link href="assets/css/theme.css" rel="stylesheet">
+    <link href="assets/css/custom.css" rel="stylesheet">
+
+    <!--[if lt IE 9]>
+    <script src="assets/plugins/iesupport/html5shiv.js"></script>
+    <script src="assets/plugins/iesupport/respond.min.js"></script>
+    <![endif]-->
+</head>
+
+<body id="home" class="wide body-light sub-page">
+
+    <!-- Preloader -->
+    <div id="preloader">
+        <div id="status">
+            <div class="spinner"></div>
+        </div>
+    </div>
+
+    <!-- Wrap all content -->
+    <div class="wrapper">
+
+        <!-- HEADER -->
+        <header class="header fixed">
+            <div class="container">
+                <div class="header-wrapper clearfix">
+
+                    <!-- Logo -->
+                    <div class="logo">
+                        <a href="http://scbcn.github.io/" class="scroll-to">
+                            <img src="assets/img/preview/logo_black.png" alt="scbcn logo" height="50px" width="50px">
+                            SCBCN17
+                        </a>
+                    </div>
+                    <!-- /Logo -->
+
+                    <!-- Navigation -->
+                    <div id="mobile-menu"></div>
+                    <nav class="navigation closed clearfix">
+                        <a href="#" class="menu-toggle btn"><i class="fa fa-bars"></i></a>
+                        <ul class="sf-menu nav">
+                            <li class="active">
+                                <a href="http://scbcn.github.io/">Home</a>
+                            </li>
+                        </ul>
+                    </nav>
+                    <!-- /Navigation -->
+                </div>
+            </div>
+        </header>
+        <!-- /HEADER -->
+
+        <!-- Content area -->
+        <div class="content-area">
+                <!-- PAGE CODE OF CONDUCT -->
+                <section class="page-section" id="coc">
+                    <div class="container">
+                        <h1 class="section-title">
+                            <span data-animation="flipInY" data-animation-delay="300" class="icon-inner"><span class="fa-stack"><i class="fa rhex fa-stack-2x"></i><i class="fa fa-star fa-stack-1x"></i></span></span>
+                            <span data-animation="fadeInRight" data-animation-delay="500" class="title-inner">Code of Conduct</span>
+                        </h1>
+                        <div class="row">
+                            <div class="col-lg-12">
+                                <p data-animation="fadeInUp" data-animation-delay="300">
+                                <p>All attendees, speakers, sponsors and volunteers at our conference are required to agree with the following code of conduct. Organizers will enforce this code throughout the event. We are expecting cooperation from all participants to help ensuring a safe environment for everybody.</p>
+
+                                <h2 class="post-title">Need Help?</h2>
+
+                                <p>You have our contact details in the emails we&#39;ve sent.</p>
+
+                                <h2 class="post-title">The Quick Version</h2>
+
+                                <p>Our conference is dedicated to providing a harassment-free conference experience for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion (or lack thereof), or technology choices. We do not tolerate harassment of conference participants in any form. Sexual language and imagery is not appropriate for any conference venue, including talks, workshops, parties, Twitter and other online media. Conference participants violating these rules may be sanctioned or expelled from the conference <em>without a refund</em> at the discretion of the conference organisers.</p>
+
+                                <h2 class="post-title">The Less Quick Version</h2>
+
+                                <p>Harassment includes offensive verbal comments related to gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion, technology choices, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention.</p>
+
+                                <p>Participants asked to stop any harassing behavior are expected to comply immediately.</p>
+
+                                <p>Sponsors are also subject to the anti-harassment policy. In particular, sponsors should not use sexualized images, activities, or other material. Booth staff (including volunteers) should not use sexualized clothing/uniforms/costumes, or otherwise create a sexualized environment.</p>
+
+                                <p>If a participant engages in harassing behavior, the conference organisers may take any action they deem appropriate, including warning the offender or expulsion from the conference with no refund.</p>
+
+                                <p>If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of conference staff immediately. Conference staff can be identified as they&#39;ll be wearing branded t-shirts.</p>
+
+                                <p>Conference staff will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance.</p>
+
+                                <p>We expect participants to follow these rules at conference and workshop venues and conference-related social events.</p>
+
+                                <p>
+                                  <small>Original source and credit: <a href="http://2012.jsconf.us/#/about">http://2012.jsconf.us/#/about</a> & <a href="http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy">The Ada Initiative</a></small>
+                                  <br/>
+                                  <small>For the Spanish version visit <a href="http://es.confcodeofconduct.com/">http://es.confcodeofconduct.com</a></small>
+                                </p>
+                              </p>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+                <!-- /PAGE CODE OF CONDUCT -->
+
+        </div>
+        <!-- /Content area -->
+        <!-- FOOTER -->
+        <footer class="footer">
+            <div class="footer-meta">
+                <div class="container text-center">
+                    <div class="clearfix">
+                        <ul class="social-line list-inline">
+                            <li data-animation="flipInY" data-animation-delay="100"><a href="//twitter.com/bcnswcraft" class="twitter" target="_blank"><i class="fa fa-twitter"></i></a></li>
+                            <li data-animation="flipInY" data-animation-delay="100"><a href="//www.youtube.com/channel/UCksw6qsw6vk7cp8sVwIpNrQ" class="youtube" target="_blank"><i class="fa fa-youtube-play"></i></a></li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </footer>
+        <!-- /FOOTER -->
+
+        <div class="to-top"><i class="fa fa-angle-up"></i></div>
+
+    </div>
+    <!-- /Wrap all content -->
+
+    <!-- JS Global -->
+
+    <!--[if lt IE 9]><script src="assets/plugins/jquery/jquery-1.11.1.min.js"></script><![endif]-->
+    <!--[if gte IE 9]><!--><script src="assets/plugins/jquery/jquery-2.1.1.min.js"></script><!--<![endif]-->
+    <script src="assets/plugins/modernizr.custom.js"></script>
+    <script src="assets/plugins/bootstrap/js/bootstrap.min.js"></script>
+    <script src="assets/plugins/bootstrap-select/bootstrap-select.min.js"></script>
+    <script src="assets/plugins/superfish/js/superfish.js"></script>
+    <script src="assets/plugins/prettyphoto/js/jquery.prettyPhoto.js"></script>
+    <script src="assets/plugins/placeholdem.min.js"></script>
+    <script src="assets/plugins/jquery.smoothscroll.min.js"></script>
+    <script src="assets/plugins/jquery.easing.min.js"></script>
+
+    <!-- JS Page Level -->
+
+    <script src="assets/js/theme-ajax-mail.js"></script>
+    <script src="assets/js/theme.js"></script>
+    <script src="assets/js/custom.js"></script>
+
+    <!--[if (gte IE 9)|!(IE)]><!-->
+    <!--script src="assets/plugins/jquery.cookie.js"></script>
+    <script src="assets/js/theme-config.js"></script-->
+    <!--<![endif]-->
+
+    <script type="text/javascript">
+        jQuery(document).ready(function () {
+            theme.init();
+        });
+
+        //jQuery(window).load(function () { jQuery('body').scrollspy({offset: 100, target: '.navigation'}); });
+        //jQuery(window).load(function () { jQuery('body').scrollspy('refresh'); });
+        //jQuery(window).resize(function () { jQuery('body').scrollspy('refresh'); });
+
+    </script>
+
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -2,10 +2,7 @@
 <!--[if lt IE 7 ]><html class="ie ie6" lang="en"><![endif]-->
 <!--[if IE 7 ]><html class="ie ie7" lang="en"><![endif]-->
 <!--[if IE 8 ]><html class="ie ie8" lang="en"><![endif]-->
-<!--[if (gte IE 9)|!(IE)]><!-->
-<html lang="en">
-<!--<![endif]-->
-
+<!--[if (gte IE 9)|!(IE)]><!--><html lang="en"><!--<![endif]-->
 <head>
     <meta charset="utf-8">
     <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
@@ -412,37 +409,7 @@
                     <div class="row">
                         <div class="col-lg-12">
                             <p data-animation="fadeInUp" data-animation-delay="300">
-                            <p>All attendees, speakers, sponsors and volunteers at our conference are required to agree with the following code of conduct. Organizers will enforce this code throughout the event. We are expecting cooperation from all participants to help ensuring a safe environment for everybody.</p>
-
-                            <h2 class="post-title">Need Help?</h2>
-
-                            <p>You have our contact details in the emails we&#39;ve sent.</p>
-
-                            <h2 class="post-title">The Quick Version</h2>
-
-                            <p>Our conference is dedicated to providing a harassment-free conference experience for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion (or lack thereof), or technology choices. We do not tolerate harassment of conference participants in any form. Sexual language and imagery is not appropriate for any conference venue, including talks, workshops, parties, Twitter and other online media. Conference participants violating these rules may be sanctioned or expelled from the conference <em>without a refund</em> at the discretion of the conference organisers.</p>
-
-                            <h2 class="post-title">The Less Quick Version</h2>
-
-                            <p>Harassment includes offensive verbal comments related to gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion, technology choices, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention.</p>
-
-                            <p>Participants asked to stop any harassing behavior are expected to comply immediately.</p>
-
-                            <p>Sponsors are also subject to the anti-harassment policy. In particular, sponsors should not use sexualized images, activities, or other material. Booth staff (including volunteers) should not use sexualized clothing/uniforms/costumes, or otherwise create a sexualized environment.</p>
-
-                            <p>If a participant engages in harassing behavior, the conference organisers may take any action they deem appropriate, including warning the offender or expulsion from the conference with no refund.</p>
-
-                            <p>If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of conference staff immediately. Conference staff can be identified as they&#39;ll be wearing branded t-shirts.</p>
-
-                            <p>Conference staff will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance.</p>
-
-                            <p>We expect participants to follow these rules at conference and workshop venues and conference-related social events.</p>
-
-                            <p>
-                              <small>Original source and credit: <a href="http://2012.jsconf.us/#/about">http://2012.jsconf.us/#/about</a> & <a href="http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy">The Ada Initiative</a></small>
-                              <br/>
-                              <small>For the Spanish version visit <a href="http://es.confcodeofconduct.com/">http://es.confcodeofconduct.com</a></small>
-                            </p>
+                            <p>All attendees, speakers, sponsors and volunteers at our conference are required to agree with the following <a href="coc.html">code of conduct</a>. Organizers will enforce this code throughout the event. We are expecting cooperation from all participants to help ensuring a safe environment for everybody.</p>
                           </p>
                         </div>
                     </div>


### PR DESCRIPTION
Move the complete version of the Code of Conduct from the homepage to its own page in order to avoid an almost infinite scroll in mobile. Link from the homepage added in order to do not lose visibility.