### PR TITLE
Adds language marker for EN talks in the title on the schedule

### DIFF
--- a/index.html
+++ b/index.html
@@ -295,7 +295,7 @@
                                     </ul>
                                 </div>
                                 <div class="tab-content lv2">
-                                    
+
                                     <!--TRACK 1-->
                                     <div id="tab-lv21-first" class="tab-pane fade in active">
                                         <div class="timeline">
@@ -408,7 +408,7 @@
                                                         <div class="post-footer">
                                                             <span class="post-readmore">
                                                                 <i class="fa fa-microphone"></i> Modesto San Juan
-                                                                <a href="https://twitter.com/@msanjuan"><i class="fa fa-twitter"></i></a>                                                               
+                                                                <a href="https://twitter.com/@msanjuan"><i class="fa fa-twitter"></i></a>
                                                             </span>
                                                         </div>
                                                         <div class="sc-avatar-wrapper">
@@ -512,7 +512,7 @@
                                                         </div>
                                                         <div class="post-footer">
                                                             <span class="post-readmore">
-                                                                <i class="fa fa-microphone"></i> Rafa Gómez 
+                                                                <i class="fa fa-microphone"></i> Rafa Gómez
                                                                 <a href="https://twitter.com/rafaoe"><i class="fa fa-twitter"></i></a>
                                                                 <i class="fa fa-microphone"></i> Javier Ferrer
                                                                 <a href="https://twitter.com/JavierCane"><i class="fa fa-twitter"></i></a>
@@ -585,7 +585,7 @@
 
                                                     </div>
                                                 </div>
-                                            </article>                                            
+                                            </article>
 
                                             <!--TALK 6-->
                                             <article class="post-wrap" data-animation="fadeInUp" data-animation-delay="300">
@@ -774,7 +774,7 @@
                                                                         <li>- Pierdan el miedo a conceptos matemáticos como Monad Transformers, explicándolos con pragmatismo.</li>
                                                                         <li>- Vean que se puede usar la programación declarativa en cualquier caso de uso real, no solo en proyectos de juguete.</li>
                                                                     </ul>
-                                                                    
+
                                                                 </p>
                                                             </div>
                                                         </div>
@@ -805,7 +805,7 @@
                                                         <div class="post-body">
                                                             <div class="post-excerpt">
                                                                 <p>
-                                                                    When embracing Java 8 we walk down the yellow brick road to the wizard of lambdas. That road usually starts from the fear and terror of learning their syntax until finally getting to understand them and opening our minds to the fruitful fields of functional programming. But this road eventually reaches a final stage: the lambda abuse. 
+                                                                    When embracing Java 8 we walk down the yellow brick road to the wizard of lambdas. That road usually starts from the fear and terror of learning their syntax until finally getting to understand them and opening our minds to the fruitful fields of functional programming. But this road eventually reaches a final stage: the lambda abuse.
                                                                     <br/>
                                                                     To master the lambdas art means to know when to use them and when not to not damage your brain and, most importantly, other Java developers’. Keep your code readable and maintainable, avoid becoming a lambda addict!
                                                                 </p>
@@ -894,7 +894,7 @@
                                                         <div class="post-body">
                                                             <div class="post-excerpt">
                                                                 <p>
-                                                                    Iniciación a la UX y presentación de técnicas y herramientas para la co-creación de la experiencia de usuario. Aportaré una visión de la disciplina como etiqueta propia de todos los roles y con acercamiento específico al rol developer. 
+                                                                    Iniciación a la UX y presentación de técnicas y herramientas para la co-creación de la experiencia de usuario. Aportaré una visión de la disciplina como etiqueta propia de todos los roles y con acercamiento específico al rol developer.
                                                                 </p>
                                                             </div>
                                                         </div>
@@ -925,7 +925,7 @@
 
                                                     </div>
                                                 </div>
-                                            </article>                                            
+                                            </article>
 
                                             <!--TALK 6-->
                                             <article class="post-wrap" data-animation="fadeInUp" data-animation-delay="300">
@@ -1090,7 +1090,7 @@
                                                                     Architectural Katas is an exercise created by Ted Neward. Similarly to code katas, the role of this session is to practice and became better at software architecture.
                                                                     The exercise normally consists on groups of 3 to 5 people, each one of them doing a different kata. The group will discuss options and sketch what a possible solution may look like. The moderator assigns the katas and acts as a "customer" answering questions from the teams. At the end, the teams present their solution to the other teams in the room, and answer challenges (in the form of hard-but-fair questions).
                                                                     This session is open to everyone, from seasoned architect to junior developers. The main goal is to practice our architectural skills by learning from each other.
-                                                                    The original Kata is described here (https://archkatas.herokuapp.com/about.html). 
+                                                                    The original Kata is described here (https://archkatas.herokuapp.com/about.html).
                                                                 </p>
                                                             </div>
                                                         </div>
@@ -1177,7 +1177,7 @@
 
                                                     </div>
                                                 </div>
-                                            </article>                                            
+                                            </article>
 
                                             <!--TALK 6-->
                                             <article class="post-wrap" data-animation="fadeInUp" data-animation-delay="300">
@@ -1284,7 +1284,7 @@
                                                             <div class="post-meta">
                                                                 <span class="post-date"><i class="fa fa-clock-o"></i> 10:00 - 10:55</span>
                                                             </div>
-                                                            <h2 class="post-title"><a href="#">Native and browser SPA versions using re-frame, ClojureScript and ReactNative</a></h2>
+                                                            <h2 class="post-title"><a href="#">Native and browser SPA versions using re-frame, ClojureScript and ReactNative (EN)</a></h2>
                                                         </div>
                                                         <div class="post-body">
                                                             <div class="post-excerpt">
@@ -1335,7 +1335,7 @@
                                                             <div class="post-meta">
                                                                 <span class="post-date"><i class="fa fa-clock-o"></i> 11:30 - 12:25</span>
                                                             </div>
-                                                            <h2 class="post-title"><a href="#">Towards an inclusive craft</a></h2>
+                                                            <h2 class="post-title"><a href="#">Towards an inclusive craft (EN)</a></h2>
                                                         </div>
                                                         <div class="post-body">
                                                             <div class="post-excerpt">
@@ -1344,7 +1344,7 @@
                                                                     <br/>
                                                                     When it comes to diversity and inclusion, our industry has an abysmal track record. Some of us in the craftsmanship community are actively working to make a difference. We believe that if craftsmanship is to remain relevant into the 2020s and beyond, we must tackle this issue head-on.
                                                                     <br/>
-                                                                    In this talk I’ll look at what key players in the software craftsmanship community have been doing to improve diversity, why it’s important we all participate, and what you can do to help. 
+                                                                    In this talk I’ll look at what key players in the software craftsmanship community have been doing to improve diversity, why it’s important we all participate, and what you can do to help.
                                                                 </p>
                                                             </div>
                                                         </div>
@@ -1369,7 +1369,7 @@
                                                             <div class="post-meta">
                                                                 <span class="post-date"><i class="fa fa-clock-o"></i> 12:30 - 13:25</span>
                                                             </div>
-                                                            <h2 class="post-title"><a href="#">Understanding the learning path</a></h2>
+                                                            <h2 class="post-title"><a href="#">Understanding the learning path (EN)</a></h2>
                                                         </div>
                                                         <div class="post-body">
                                                             <div class="post-excerpt">
@@ -1421,7 +1421,7 @@
                                                             <div class="post-meta">
                                                                 <span class="post-date"><i class="fa fa-clock-o"></i> 15:00 - 15:55</span>
                                                             </div>
-                                                            <h2 class="post-title"><a href="#">Ecosystem of a Linux Distribution.</a></h2>
+                                                            <h2 class="post-title"><a href="#">Ecosystem of a Linux Distribution (EN)</a></h2>
                                                         </div>
                                                         <div class="post-body">
                                                             <div class="post-excerpt">
@@ -1451,14 +1451,14 @@
                                                             <div class="post-meta">
                                                                 <span class="post-date"><i class="fa fa-clock-o"></i> 16:00 - 16:55</span>
                                                             </div>
-                                                            <h2 class="post-title"><a href="#">Tackling transactions in Microservices applications</a></h2>
+                                                            <h2 class="post-title"><a href="#">Tackling transactions in Microservices applications (EN)</a></h2>
                                                         </div>
                                                         <div class="post-body">
                                                             <div class="post-excerpt">
                                                                 <p>
-                                                                    ACID transactions in a monolithic application are a great, powerful and simple tool, that helps us guaranteeing data consistency inside our application. 
+                                                                    ACID transactions in a monolithic application are a great, powerful and simple tool, that helps us guaranteeing data consistency inside our application.
                                                                     <br/>
-                                                                    But... what happens when we move from monolithic applications to distributed systems? We don't have a single database or ACID transactions anymore, and there is also a choice to make regarding the CAP theorem. But... is all hope lost? Or can we still somehow have transactions across service boundaries? 
+                                                                    But... what happens when we move from monolithic applications to distributed systems? We don't have a single database or ACID transactions anymore, and there is also a choice to make regarding the CAP theorem. But... is all hope lost? Or can we still somehow have transactions across service boundaries?
                                                                     <br/>
                                                                     In this talk we will try to understand that complexity, see some alternatives, and how the SAGA pattern comes to the rescue here.
                                                                 </p>
@@ -1495,7 +1495,7 @@
 
                                                     </div>
                                                 </div>
-                                            </article>                                            
+                                            </article>
 
                                             <!--TALK 6-->
                                             <article class="post-wrap" data-animation="fadeInUp" data-animation-delay="300">
@@ -1505,7 +1505,7 @@
                                                             <div class="post-meta">
                                                                 <span class="post-date"><i class="fa fa-clock-o"></i> 17:30 - 18:25</span>
                                                             </div>
-                                                            <h2 class="post-title"><a href="#">What's the Actor model and why should I use it.</a></h2>
+                                                            <h2 class="post-title"><a href="#">What's the Actor model and why should I use it (EN)</a></h2>
                                                         </div>
                                                         <div class="post-body">
                                                             <div class="post-excerpt">
@@ -1565,7 +1565,7 @@
                                     </ul>
                                 </div>
                                 <div class="tab-content lv2">
-                                    
+
                                     <!--TRACK 1-->
                                     <div id="tab-lv22-first" class="tab-pane fade in active">
                                         <div class="timeline">
@@ -1617,7 +1617,7 @@
                                                             <div class="post-meta">
                                                                 <span class="post-date"><i class="fa fa-clock-o"></i> 10:00 - 10:55</span>
                                                             </div>
-                                                            <h2 class="post-title"><a href="#">Surprise!</a></h2>
+                                                            <h2 class="post-title"><a href="#">Surprise! (EN)</a></h2>
                                                         </div>
                                                         <div class="post-body">
                                                             <div class="post-excerpt">
@@ -1628,7 +1628,7 @@
                                                         </div>
                                                         <div class="post-footer">
                                                             <span class="post-readmore">
-                                                                <i class="fa fa-microphone"></i> Sandro Mancuso 
+                                                                <i class="fa fa-microphone"></i> Sandro Mancuso
                                                                 <a href="https://twitter.com/sandromancuso"><i class="fa fa-twitter"></i></a>
                                                             </span>
                                                         </div>
@@ -1667,12 +1667,12 @@
                                                             <div class="post-meta">
                                                                 <span class="post-date"><i class="fa fa-clock-o"></i> 11:30 - 12:25</span>
                                                             </div>
-                                                            <h2 class="post-title"><a href="#">Ten lessons learned on API performance optimization</a></h2>
+                                                            <h2 class="post-title"><a href="#">Ten lessons learned on API performance optimization (EN)</a></h2>
                                                         </div>
                                                         <div class="post-body">
                                                             <div class="post-excerpt">
                                                                 <p>
-                                                                    One day, you learn that you will be responsible for the company’s externally facing API. 
+                                                                    One day, you learn that you will be responsible for the company’s externally facing API.
                                                                     <br/>
                                                                     It is a strategic product for the business and expected to have more and more users in the next few months. However, you also know that the existing API has various performance problems and multiple clients have been complaining. Where would you start?
                                                                 </p>
@@ -1695,7 +1695,7 @@
                                                             <div class="post-meta">
                                                                 <span class="post-date"><i class="fa fa-clock-o"></i> 12:30 - 13:25</span>
                                                             </div>
-                                                            <h2 class="post-title"><a href="#">What I've learned by dealing with a Dungeon Master</a></h2>
+                                                            <h2 class="post-title"><a href="#">What I've learned by dealing with a Dungeon Master (EN)</a></h2>
                                                         </div>
                                                         <div class="post-body">
                                                             <div class="post-excerpt">
@@ -1762,7 +1762,7 @@
                                                     </div>
                                                 </div>
                                             </article>
-                                       
+
                                             <!--CLOSING -->
                                             <article class="post-wrap" data-animation="fadeInUp" data-animation-delay="300">
                                                 <div class="media">
@@ -1930,7 +1930,7 @@
                                                         <div class="post-body">
                                                             <div class="post-excerpt">
                                                                 <p>
-                                                                    La deuda técnica existe, y quien diga lo contrario miente. 
+                                                                    La deuda técnica existe, y quien diga lo contrario miente.
                                                                     <br/>
                                                                     De hecho, raro es el proyecto en el que uno aterriza y está todo como si lo hubiera escrito el mismísimo Uncle Bob. Ahora bien, ¿Qué pasa si el desaguisado es tal que el propio proyecto se hace inmanejable? ¿Cómo podemos explicar al cliente que hay que invertir parte del presupuesto en deshacerlo? Esta charla pretende dar algunas ideas que esperamos os sean útiles sobre cómo, cuándo y por qué puede ser necesario vender un proyecto de refactoring sin necesidad de sacar una navaja  (^_^)
                                                                 </p>
@@ -1999,7 +1999,7 @@
                                                     </div>
                                                 </div>
                                             </article>
-                                       
+
                                             <!--CLOSING -->
                                             <article class="post-wrap" data-animation="fadeInUp" data-animation-delay="300">
                                                 <div class="media">
@@ -2084,15 +2084,15 @@
                                                                     <br/>
                                                                     It's expensive, requires tecnical expertise, time and machines...
                                                                     The problem is that without CD you are walking around with a hole in your pocket and the hole is getting bigger...
-                                                                    <br/>                                                                    
                                                                     <br/>
-                                                                    This presentation focusses on the 3 main reasons why the hole is there... and growing. They are the ABC of Continuous Delivery: 
+                                                                    <br/>
+                                                                    This presentation focusses on the 3 main reasons why the hole is there... and growing. They are the ABC of Continuous Delivery:
                                                                     <ul>
                                                                         <li>- Amplification: Deploying takes more time the longer the time between deploys.</li>
                                                                         <li>- Bugs: Bugs are more costly to fix the longer ago they were introduced.</li>
                                                                         <li>- Cost of Delay (CoD): The longer you take between deploys, the longer your cost of delay</li>
-                                                                    </ul>   
-                                                                    <br/>                                                                    
+                                                                    </ul>
+                                                                    <br/>
                                                                     In the model we present, one can see the costs of integration and deploy are super linear to the number of changes to integrate. In Software Development, the commits that are not yet in production are inventory... and inventory is waste.
                                                                 </p>
                                                             </div>
@@ -2170,7 +2170,7 @@
                                                     </div>
                                                 </div>
                                             </article>
-                                           
+
                                             <!--LUNCH-->
                                             <article class="post-wrap" data-animation="fadeInUp" data-animation-delay="300">
                                                 <div class="media">
@@ -2299,7 +2299,7 @@
                                                                 <p>
                                                                     ¡Frena! ¿Cómo vas tan rápido por una carretera con curvas? Muchas veces los desarrolladores conducen a lo loco por su carrera programando sin aprender las técnicas adecuadas de conducción. ¿El resultado? Muchos accidentes...
                                                                     <br/>
-                                                                    La motivación de esta charla es presentar un catálogo de principios de diseño de programación orientada a objetos con ejemplos que permitan entenderlos. ¿El objetivo? Evitar accidentes. 
+                                                                    La motivación de esta charla es presentar un catálogo de principios de diseño de programación orientada a objetos con ejemplos que permitan entenderlos. ¿El objetivo? Evitar accidentes.
                                                                     <br/>
                                                                     Veremos algunos principios como KISS, DRY, POLA, SOLID, SoC, YAGNI, LoD, HP, CRP, TDAP, entre otros...
                                                                 </p>
@@ -2397,7 +2397,7 @@
                                                     <!-- -->
                                                 </div>
                                             </article>
-                                            
+
                                             <!--OPEN SPACE-->
                                             <article class="post-wrap" data-animation="fadeInUp" data-animation-delay="300">
                                                 <div class="media">


### PR DESCRIPTION
When a session is in english, the session title in the shecul includes a `(EN)` marker.