### PR TITLE
Minor set of fixes

### DIFF
--- a/404.html
+++ b/404.html
@@ -63,8 +63,8 @@
                 <!-- Logo -->
                 <div class="logo">
                     <a href="index.html" class="scroll-to">
-                        <img src="assets/img/preview/logo_white.png" alt="scbcn logo" height="50px" width="50px">
-                        SCBCN22
+                        <img src="assets/img/preview/logo.png" alt="scbcn logo" height="35px" width="46px">
+                        SCBCN23
                     </a>
                 </div>
                 <!-- /Logo -->

--- a/coc.html
+++ b/coc.html
@@ -61,8 +61,8 @@
                     <!-- Logo -->
                     <div class="logo">
                         <a href="http://scbcn.github.io/" class="scroll-to">
-                            <img src="assets/img/preview/logo_white.png" alt="scbcn logo" height="50px" width="50px">
-                            SCBCN22
+                            <img src="assets/img/preview/logo.png" alt="scbcn logo" height="35px" width="46px">
+                            SCBCN23
                         </a>
                     </div>
                     <!-- /Logo -->

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -56,8 +56,8 @@
                     <!-- Logo -->
                     <div class="logo">
                         <a href="index.html" class="scroll-to">
-                            <img src="assets/img/preview/logo_white.png" alt="scbcn logo" height="50px" width="50px">
-                            SCBCN22
+                            <img src="assets/img/preview/logo.png" alt="scbcn logo" height="50px" width="50px">
+                            SCBCN23
                         </a>
                     </div>
                     <!-- /Logo -->


### PR DESCRIPTION
- [ ] Borrar el link “home” del menú
- [ ] Pujar la tipo del menú a 18px
- [ ] Baixar el fons del hero per que es vegi el verd més
- [ ] El text de l’esquerra treureli el bold i pujarlo a 80px
- [ ] El text de la dreta del hero:
  - [ ] El 10th edition alineat a l’esquerra
  - [ ] La tipo es Poppins i semibold
  - [ ] Afegir una mica de marge entre iconeta i text
- [ ] Ajuntar una mica els dos blocs de textos per que estiguin mes centradets
- [ ] Treure una mica de padding superior i inferior al CTA
- [ ] La tipo dels CTA amb ‘Barlow Condensed’
- [ ] Els títols de les seccions amb ‘Barlow Condensed’
- [ ] El hover de les imatges de la dreta de “About the event” en taronja
- [ ] La llista dins “About the event” que sigui una llista real (em dona una mica toc veure una llista amb guionets haha)
- [ ] Borrar subtítol “general” y “hotels”
- [ ] Els enllaços ferlos blaus amb underline i taronjes on hover
- [ ] Les icones del footer de Twitter i Youtube posarles tronjes i verd on hover